### PR TITLE
docs: drop the filename rule, the app no longer cares

### DIFF
--- a/dataprep/datachecks.rst
+++ b/dataprep/datachecks.rst
@@ -30,9 +30,7 @@ this list accordingly. The characters below are strictly forbidden.
 
 **Check #2** Avoid starting your sample, phenotype or contrast names with special characters like (+, -, *, /, %, etc..). While the platform will accept these characters, they may be converted into a standard symbol like X. For example, if we label the sample.csv country column as `%country`, we will see X.country in some analysis in Omics Playground.
 
-**Check #3** Make sure you have the words 'samples', 'counts' and 'contrasts' in the corresponding filenames. For example, we accept experiment23_samples.csv, samples_experiment23.csv, but not experiment23.csv as sample input.
-
-**Check #4**. Define intervals instead of using numeric phenotypes.
+**Check #3**. Define intervals instead of using numeric phenotypes.
 The platform does not cope with continuous numeric variables for phenotypes yet. To avoid that, our coders added a filter that flags phenotypes names “Time” or “Age” as unacceptable. The same applies for other continuous variables, such as height, weight, length, etc.
 
 Instead, you should cluster the various numeric values into definite intervals and then name them accordingly (e.g. “Age_groups”, “Time_intervals”, etc…)


### PR DESCRIPTION
Drop the filename rule from data checks


Check #3 removed, #4 renumbered. Pairs with bigomics/omicsplayground#1831.